### PR TITLE
Drop the schedule's source path

### DIFF
--- a/docs/automation/automations.md
+++ b/docs/automation/automations.md
@@ -31,7 +31,7 @@ In the dialog that opens, fill out the following:
   * `File infected` — malware scanning found a file to be infected. Available when malware scanning is enabled.
 * `Filter` (optional) — for an event trigger, only run the automation when the triggering event matches your rules. Filter on the file `Path`, the `Actor ID`, or the `Actor Type`, using operators such as `Starts with`, `Ends with`, `Contains` or `Matches` — for example, only files whose path starts with `/incoming/`, or only files ending with `.csv`.
 * `Schedule` — for a schedule trigger, when and how often to run. See [Running on a schedule](#running-on-a-schedule).
-* `Actions` — the actions to run, in order. An automation can have up to 5 actions.
+* `Actions` — the actions to run, in order. An automation can have up to 10 actions.
 
 Click **Save** to create the automation. It starts running on matching events immediately, unless you create it paused.
 
@@ -52,8 +52,9 @@ Choose **On a schedule** as the trigger, then set:
   * `On rate-based schedule` — repeats every set number of minutes, hours, days or weeks, spaced evenly from the start.
   * `On cron-based schedule` — for patterns the options above can't describe, using standard cron syntax. See [Cron expressions](#cron-expressions).
 * `Ends` (optional) — `Never`, on a date, or after a set number of runs.
-* `Source path` — the file or folder the actions run on each time. A schedule has no triggering file, so this is what the automation acts on. Variables are supported, so a path such as `/incoming/{{date.year}}-{{date.month}}-{{date.day}}/` follows the calendar.
 * `If a run is already in progress` — `Skip the run` (the default) drops the new run so only one is ever in flight; `Run anyway` starts it regardless, allowing runs to overlap.
+
+Because a schedule has no triggering file, an action that reads one — copy, move, rename, delete, or either PGP action — must say which file it means. Set its source to **A specific file or folder** and give the path; variables are supported, so `/incoming/{{date.year}}-{{date.month}}-{{date.day}}/` follows the calendar. An action that reads nothing (creating a file or folder, or a delay), or that only describes the run (the notifications), needs no path at all. An action can also work on **the file or folder created by the previous action**, so only the first step in a chain needs a path.
 
 While you're editing, the editor describes the schedule in words — "Every day at 9:00 AM", "At 09:00 AM, Monday through Friday" — and lists the runs it produces next, so you can check the cadence before saving. Those runs are shown in your own time zone rather than the schedule's, so a schedule set in another region still tells you when it lands for you; hover a date to see it spelled out.
 
@@ -172,13 +173,13 @@ The request body is a JSON object describing the triggering event, with a `Metad
 
 `Metadata.ApiVersion` identifies the payload format, so you can branch on it if the format ever changes. It matches the **API version** selected on the action.
 
-For a scheduled run the same shape is sent, with the differences a schedule implies: the `Topic` is `schedule.triggered`, `Data.Path` is the schedule's source path with any variables resolved, `Data.Size` is `null` because no file was transferred, and the `Actor` is the automation itself:
+For a scheduled run the same shape is sent, with the differences a schedule implies: the `Topic` is `schedule.triggered`, the `Resource` is `Schedule` rather than `File`, `Data` is empty because no file was transferred, and the `Actor` is the automation itself:
 
 ```json
 {
   "Topic": "schedule.triggered",
-  "Resource": "File",
-  "Data": { "Path": "reports/daily.csv", "Size": null },
+  "Resource": "Schedule",
+  "Data": {},
   "Actor": { "Id": "<automation id>", "Type": "Automation" }
 }
 ```
@@ -284,7 +285,7 @@ The [Send email](#send-email) action is delivered by our email provider, so its 
 
 ## Variables
 
-Destination paths, new names, webhook endpoint URLs and a schedule's source path can include variables, which are replaced with real values when the automation runs.
+Destination paths, source paths, new names and webhook endpoint URLs can include variables, which are replaced with real values when the automation runs.
 
 | Variable | Description | Example |
 |--|--|--|
@@ -318,13 +319,13 @@ A variable that doesn't match any of the names above is not replaced, and the ac
 
 Every run of an automation is recorded as an execution, showing whether it succeeded and the state and result of each individual action, including the error reported by any action that failed. Executions are retained for 30 days.
 
-Expanding a run shows what it worked on. For a file event that's the file that triggered it — its path and size. For a scheduled run there is no triggering file, so it shows the schedule it belongs to and the source path the run used, with any variables already substituted, so you see the path the actions actually received rather than the template. A run started with **Run now** shows the same details.
+Expanding a run shows what it worked on. For a file event that's the file that triggered it — its path and size. For a scheduled run there is no triggering file, so it shows the schedule it belongs to; each action shows the path it worked on, with any variables already substituted, so you see the path the action actually received rather than the template. A run started with **Run now** shows the same details.
 
 To view an automation's executions, open its actions menu and click **View executions**.
 
 ### Running an automation manually
 
-Open an automation's actions menu and click **Run now** to run it on demand, without waiting for a matching event or for its next scheduled time — useful for testing an automation or reprocessing a specific file. For an event-triggered automation, enter the file path and pick the trigger event to record on the run. A scheduled automation runs against its own source path, so there's nothing to enter.
+Open an automation's actions menu and click **Run now** to run it on demand, without waiting for a matching event or for its next scheduled time — useful for testing an automation or reprocessing a specific file. For an event-triggered automation, enter the file path and pick the trigger event to record on the run. A scheduled automation's actions carry their own paths, so there's nothing to enter.
 
 A manual run ignores the automation's filter and runs its real actions, so it may change files in your storage. It runs even when the automation is paused or disabled, which lets you test a fix before resuming. Manual runs are shown with a **Run now** marker in the execution history and recorded in your [audit logs](../security/audit-logs#automations) as `automation.execution.manual-run`.
 

--- a/docs/automation/automations.md
+++ b/docs/automation/automations.md
@@ -251,7 +251,7 @@ Emails a notification describing the triggering event.
 * `Recipient email` — the address to send the notification to.
 
 :::note
-When the automation runs on a schedule there is no file event to describe, so the Slack, Microsoft Teams and email notifications say the automation ran on schedule and name the path it ran on.
+When the automation runs on a schedule there is no file event to describe, so the Slack, Microsoft Teams and email notifications say the automation ran on schedule, and give the time it ran. There is no file to name — a schedule doesn't act on one, and each action carries its own path. To have a notification name a file, set its source to **the file or folder created by the previous action**: it then describes that file, as it would for a file event.
 :::
 
 ## Allowing our IP addresses

--- a/docs/security/audit-logs.md
+++ b/docs/security/audit-logs.md
@@ -34,7 +34,7 @@ CSV file structure:
 |Timestamp (UTC) |	Time and date at which the event took place  (UTC)|
 |Type|	Name of the specific event. e.g. `share-link.access-failed`, `share-link.access-expired`, `share-link.access-limit-reached`, `user.access-expired`, `user.login-failed`, `user.login`, `user.logout`, `user.password-updated`, `user.password-reset-email-sent`, `user.access-denied`, `file.created`, `file.deleted`, `file.downloaded`, `file.access-denied`, `audit-logs.streaming-destination.created`, `audit-logs.streaming-destination.updated`, `audit-logs.streaming-destination.deleted`, `audit-logs.streaming-destination.failed`, `webhook.delivery.failed`, `webhook.paused`, `automation.created`, `automation.updated`, `automation.deleted`, `automation.paused`, `automation.resumed`, `automation.execution.rerun`, `automation.execution.manual-run`, `automation.secret.rotated`, `automation.action.executed`, `automation.action.failed`, `automation.execution.failed`|
 |Principal ID|	ID of the principal responsible for the event|
-|Principal Type|	Type of the principal responsible for the event. e.g. `user`, `share-link`, `admin`, `system`, `iam` (a direct S3 request made with IAM credentials)|
+|Principal Type|	Type of the principal responsible for the event. e.g. `user`, `share-link`, `admin`, `automation` (an automation of yours, identified by its id), `system` (SFTP To Go itself), `iam` (a direct S3 request made with IAM credentials)|
 |Username|	Username of the principal responsible for the event|
 |Session ID|	ID of the event session|
 |IP Address|	IP address of the event actor|
@@ -61,17 +61,17 @@ Administrative events are attributed to the admin who made the change:
 |`automation.execution.manual-run`| An admin ran an automation on demand against a file they chose. The `Data` object's `AutomationId` is the automation and `NewExecutionId` is the execution the run created |
 |`automation.secret.rotated`| An admin rotated the automation's webhook signing secret. The `Data` object's `Id` is the automation |
 
-The remaining events are recorded by the system, so their principal type is `system` rather than the admin who created the automation:
+The remaining events aren't recorded by an admin. Those an automation causes carry the principal type `automation`, with the automation's id as the principal id — not the admin who created it. That is deliberately distinct from `system`, which is SFTP To Go's own work, so you can filter your automations apart from the platform. The exception is `automation.paused`, which is the platform's decision rather than the automation's, and stays `system`:
 
 | Type | Description |
 |--|--|
-|`automation.paused`| An automation was paused, either by an admin or automatically after consecutive failed executions. When paused automatically, the `Data` object includes a `Reason` of `consecutive-execution-failures` and the `ConsecutiveFailuresCount` |
+|`automation.paused`| An automation was paused, either by an admin or automatically after consecutive failed executions. When paused automatically, the `Data` object includes a `Reason` of `consecutive-execution-failures` and the `ConsecutiveFailuresCount`. Recorded with the `system` principal — pausing is our decision, not the automation's |
 |`automation.action.executed`| An automation action ran — any action, including the notification ones. The `Data` object's `Id` is the execution, plus the `AutomationId`, `ActionId` and `ActionType`, and for actions that act on a file the `SourcePath` and `DestinationPath` involved. A PGP action also records the key it used as `PgpKeyName` and `PgpKeyKeyId` (its OpenPGP key id), plus the internal `PgpKeyId` |
 |`automation.action.failed`| An automation action failed. Recorded even when the automation is set to continue past the failure, in which case the execution itself may still succeed. The `Data` object carries the execution `Id`, `AutomationId`, `ActionId`, `ActionType`, the `Error`, any `SourcePath` / `DestinationPath` involved, and for a PGP action the key it used (`PgpKeyName`, `PgpKeyKeyId`, `PgpKeyId`) |
-|`automation.execution.failed`| An automation execution failed. The `Data` object's `Id` is the execution, plus the `AutomationId`, the `Path` it ran on, the `TriggerType` that started it (`event`, `schedule`, `manual` or `rerun`), and the `Error` reported by the failing action |
+|`automation.execution.failed`| An automation execution failed. The `Data` object's `Id` is the execution, plus the `AutomationId`, the `TriggerType` that started it (`event`, `schedule`, `manual` or `rerun`), and the `Error` reported by the failing action. `Path` is present only when the execution was started by a file event, and names that file — a scheduled run has no triggering file, so the field is absent. Treat it as optional |
 
 :::note
-Automations act on your files using SFTP To Go's own credentials, so the resulting `file.created` and `file.deleted` events are attributed to the `system` principal. Every automation action also records an `automation.action.executed` event — use it to trace a file back to the automation and execution responsible for it, and to see that a notification step ran.
+Automations act on your files using SFTP To Go's own credentials, so the resulting `file.created` and `file.deleted` events are attributed to the `system` principal — **not** `automation`, even though the automation's own events are. The file event can't tell which automation wrote the file, or that an automation wrote it at all. Every automation action also records an `automation.action.executed` event, which can: use it to trace a file back to the automation and execution responsible for it, and to see that a notification step ran.
 :::
 
 ## Streaming audit logs {#stream}


### PR DESCRIPTION
A scheduled automation no longer carries one source path that every action inherits.

A schedule has no triggering file, and each action already names whatever it acts on, so the field was a second way to say the same thing — with a precedence rule between them — and it forced a path onto schedules whose actions never read one.

The docs now say what a scheduled automation's actions actually need, in the place the reader is already deciding it:

* an action that reads a file (copy, move, rename, delete, PGP) must say which file
* an action that reads nothing, or only describes the run, needs no path
* only the first step of a chain needs one, since a later action can work on what the previous one produced

The sample notification payload for a scheduled run was wrong twice over — it declared a `File` for a run that has none, and showed a path that no longer exists. It now reports `Resource: "Schedule"` with an empty `Data`.

Also corrects the action limit, which still said five.