### PR TITLE
Document the Print file action in the web portal

### DIFF
--- a/docs/how-to-connect/connect-web-portal.md
+++ b/docs/how-to-connect/connect-web-portal.md
@@ -40,10 +40,13 @@ Each item includes a menu button (...) for actions such as:
 
 * Download file
 * Open file in browser
+* Print file
 * Rename file
 * Duplicate file (create a copy within same folder)
 * Copy or move file to another folder
 * Copy file path to clipboard.
+
+**Print** is available for files the browser can display: PDFs, images, plain text and code, CSV and TSV spreadsheets, and Markdown. When previewing one of these files you can also press `Cmd`+`P` (or `Ctrl`+`P`) to print it. Some browsers cannot print PDFs directly — in that case the file opens in a new tab so you can print it from there.
 
 ### Bulk oprations
 


### PR DESCRIPTION
Documents the new **Print** action in the web portal's file browser.

- Adds "Print file" to the list of per-item menu actions.
- Adds a short paragraph covering which file types can be printed (PDFs, images, plain text and code, CSV and TSV, Markdown), the `Cmd`/`Ctrl`+`P` shortcut while previewing a file, and the fact that some browsers open the file in a new tab to print instead of printing directly.

Kept to product-level language — no infrastructure details.